### PR TITLE
Fix usepackage declaration in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Your LaTeX document's preamble should look like:
 \documentclass[aspectratio=169,12pt]{beamer}
 % Aspect ratios: 169 (16:9), 1610 (16:10), 149 (14:9), 32 (3:2), 141 (1.41:1), 43 (4:3), 54 (5:4)
 
-\usepackage[package options]{latexpresents/latexpresents.sty}
+\usepackage[package options]{latexpresents/latexpresents}
 
 %...
 


### PR DESCRIPTION
This is a one-line change in the readme that removes the `.sty` from the `usepackage` declaration in the readme. My version of TeXlive (2023) does not find the file otherwise, because it automatically appends `.sty` to files included with `usepackage`.

(I checked that [the demo](https://github.com/robotic-esp/latexpresents_example) is correct.)