### PR TITLE
Clone via ssh instead of https

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Most slides will have a hierarchy like:
 ## Installation and Use
 This package should be checked out as a subfolder to your LaTeX project named `latexpresents`:
 ```bash
-git clone https://github.com/robotic-esp/latexpresents.git latexpresents
+git clone git@github.com:robotic-esp/latexpresents.git
 ```
 
 This package is then used in your LaTeX project directly as cloned from the repository.


### PR DESCRIPTION
This changes the protocol for cloning from `https` to `ssh` in the readme instructions.

I only removed the explicit specification of `latexpresents` as folder name because that's the default and I didn't see a reason for it to be there.